### PR TITLE
Update home buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.13.1
+- removed new tab attribute from Future Grade Nines links on schools
+
 ## 2.13.0
 + rejigging home buttons
 

--- a/home.php
+++ b/home.php
@@ -48,7 +48,7 @@
       $parsed_url = parse_url(site_url());
       $host = explode('.', $parsed_url['host']);
       $abc = $host[0];
-      $grade_nine_button_secondary = '<p><a href="https://' .$abc.'.wrdsb.ca/future-grade-nines/" onclick="ga(\'send\',\'event\',\'schoolBanners\',\'click_banner\',\'future-grade-nines\'" target="_blank" rel="noopener"><img src="https://www.wrdsb.ca/wp-content/uploads/Button-2.jpg" alt="Future Grade Nines" /></a></p>';
+      $grade_nine_button_secondary = '<p><a href="https://' .$abc.'.wrdsb.ca/future-grade-nines/" onclick="ga(\'send\',\'event\',\'schoolBanners\',\'click_banner\',\'future-grade-nines\'"><img src="https://www.wrdsb.ca/wp-content/uploads/Button-2.jpg" alt="Future Grade Nines" /></a></p>';
       $button_sdlp = '<p><a href="https://www.wrdsb.ca/returntoschool/distance-learning-programs/secondary-distance-learning-program/" onclick="ga(\'send\',\'event\',\'schoolBanners\',\'click_banner\',\'secondary-distance-learning-program\'" target="_blank" rel="noopener"><img src="https://www.wrdsb.ca/wp-content/uploads/SDLP-Button.png" alt="Secondary Distance Learning Program" /></a></p>';
       $button_eighteen = '<div class="register" style="background-color:#FFDD4F;margin-top: 15px;color: #000;-webkit-box-shadow: 5px 5px 20px -7px rgba(255, 221, 79, 1);-moz-box-shadow: 5px 5px 20px -7px rgba(255, 221, 79, 1);box_shadow: 5px 5px 20px -7px rgba(255, 221, 79, 1);"><a href="https://www.wrdsb.ca/about-the-wrdsb/policiesprocedures/release-of-student-information/consent-for-information-sharing-for-adult-students/" style="color: #000;" target="_blank" rel="noopener">Are you turning 18 soon?</a></div>';
      }

--- a/style.css
+++ b/style.css
@@ -3,7 +3,7 @@ Theme Name: WRDSB
 Theme URI: https://github.com/wrdsb/wordpress-theme
 Author: Suzanne Carter, Rizwan Kiyani, James Schumann
 Description: The WRDSB's default WordPress theme
-Version: 2.13.0
+Version: 2.13.1
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Tags: responsive-layout, three-columns, two-columns, one-column, accessibility-ready, sticky-post, custom-menu, featured-images, custom-header, fixed-layout


### PR DESCRIPTION
- remove target from Future Grade Nines link on secondary sites